### PR TITLE
Reset existing overrides when adjusting cruise speed.

### DIFF
--- a/EasyThrottleControl/Program.cs
+++ b/EasyThrottleControl/Program.cs
@@ -574,6 +574,7 @@ namespace IngameScript
                         //If vessel is going faster then the wanted speed
                         if (speedDifferance > deadZone)
                         {
+                            DisableThrusterOverideAll();
                             if (eco_mode)
                                 SetSeparateThrusterPercent(throttle, throttleHY, ref forwardThrusters);
                             else
@@ -581,6 +582,7 @@ namespace IngameScript
                         }
                         else if (speedDifferance < -deadZone)
                         {
+                            DisableThrusterOverideAll();
                             if (eco_mode)
                                 SetSeparateThrusterPercent(throttle, throttleHY, ref backwardThrusters);
                             else
@@ -631,6 +633,7 @@ namespace IngameScript
                         //If vessel is going faster then the wanted speed
                         if (speedDifferance > deadZone)
                         {
+                            DisableThrusterOverideAll();
                             if (eco_mode)
                                 SetSeparateThrusterPercent(throttle, throttleHY, ref forwardThrusters);
                             else
@@ -638,6 +641,7 @@ namespace IngameScript
                         }
                         else if (speedDifferance < -deadZone)
                         {
+                            DisableThrusterOverideAll();
                             if (eco_mode)
                                 SetSeparateThrusterPercent(throttle, throttleHY, ref backwardThrusters);
                             else


### PR DESCRIPTION
This is a bug report and a pull request.

The bug is this: the script does not reset thruster overrides if it has to change direction suddenly in cruise or cruise+ mode.

To reproduce this, consider the following.

1. Set up hotkeys as used below.
2. Put the script in cruise mode at 50m/s and let your ship stabilize at that speed.
3. Use a hotkey to change the cruise speed to 200m/s (Run, argument `200`).
4. While the ship is still accelerating, use a hotkey to change the cruise speed back to 50m/s (Run argument `50`).

The expected behaviour at this point is that the forward thrusters will shut off, and the backward thrusters will engage to reduce the speed. The _actual_ behaviour at this point is that the forward thrusters remain overridden at 100%, and the backwards thrusters also engage to try to reduce the speed.

Best case, if the thrusters are balanced, is that you are now maintaining speed with both sets of thrusters at 100% override. More probably, if the thrusters are not balanced, whichever side has more thrust will "win," and either slowly (and expensively) accelerate the ship anyways even though the setpoint is now slower than the ship's actual speed, or slowly (and expensively) decelerate the ship to the setpoint, then stay on fighting the ship's own thrust to try to maintain speed.

This pull request adds a couple of calls to disable thruster overrides before setting the propelling overrides in cruise and cruise+ modes. This change causes it to clear overrides (blindly) every tick while accelerating or decelerating, so that cruise always seeks towards the setpoint without fighting its own past overrides.

No similar changes are needed for the governor and decoupled modes that I can see, as they do not respect commanded speeds: all speed changes in those modes require the user to hit a control direction, which triggers the logic in input handling that clears overrides.

Thank you for the wonderful script!